### PR TITLE
Feature/sns 343

### DIFF
--- a/new-scrapers/geovoile_modern_scraper.js
+++ b/new-scrapers/geovoile_modern_scraper.js
@@ -374,6 +374,17 @@ async function registerFailed(url, redirectUrl, err) {
             continue;
         }
 
+        if (
+            !result ||
+            (result.geovoileRace.eventState !== 'FINISH' &&
+                result.geovoileRace.raceState !== 'FINISH')
+        ) {
+            console.log(
+                `Race ${url} is not finished, current state = ${result.geovoileRace.raceState}, event state = ${result.geovoileRace.eventState}, temporary ignore this race`
+            );
+            continue;
+        }
+
         processedUrls.add(result.geovoileRace.url);
         processedUrls.add(result.geovoileRace.scrapedUrl);
         const { geovoileRace } = result;
@@ -449,16 +460,6 @@ async function registerFailed(url, redirectUrl, err) {
             );
         }
 
-        if (
-            !result ||
-            (result.geovoileRace.eventState !== 'FINISH' &&
-                result.geovoileRace.raceState !== 'FINISH')
-        ) {
-            console.log(
-                `Race ${url} is not finished, current state = ${result.geovoileRace.raceState}, event state = ${result.geovoileRace.eventState}, temporary ignore this race`
-            );
-            continue;
-        }
         try {
             console.log(`Sending json file to raw-data-server for url: ${url}`);
             await createAndSendTempJsonFile(result);


### PR DESCRIPTION
I run scraper from 2016 to 2021 and fix the problem of:
- Redirection causes duplicated urls as you suggested
- Typos as you suggested

There are 124 pages to be scraped. 13 of them failed.
I checked all failed pages, they are inaccessible or broken. So That's is the expected result for scraper

"https://tropheejulesverne.sodebo.com/cartographie/"
"https://www.volvooceanrace.com/static/tracker/leg11.html"
"https://transat-jacques-vabre.geovoile.com/2017/"
"https://www.volvooceanrace.com/static/tracker/leg09.html"
"https://www.volvooceanrace.com/static/tracker/leg19.html"
"https://www.volvooceanrace.com/static/tracker/leg08.html"
"https://www.volvooceanrace.com/static/tracker/leg07.html"
"https://www.volvooceanrace.com/static/tracker/leg06.html"
"https://www.volvooceanrace.com/static/tracker/leg03.html"
"http://tracking2016.vendeeglobe.org/gv5ip0/"
"https://www.volvooceanrace.com/static/tracker/leg04.html"
"https://www.volvooceanrace.com/static/tracker/leg01.html"
"https://www.volvooceanrace.com/static/tracker/leg02.html"