### PR TITLE
SNS-1147 - Fixed Georacing scraper not connecting reused course element to its positions

### DIFF
--- a/new-scrapers/georacing_scraper.js
+++ b/new-scrapers/georacing_scraper.js
@@ -399,8 +399,11 @@ const {
                     }
 
                     if (positionSave.length === 0 && !isUnfinished) {
-                        console.log('No positions. Skipping.');
-                        continue;
+                        throw new Error('No positions in race');
+                    }
+
+                    if (actorSave.length === 0 && !isUnfinished) {
+                        throw new Error('No boats in race');
                     }
 
                     objectsToSave.GeoracingRace.push(raceObjSave);
@@ -2140,8 +2143,12 @@ function getCoursesData(courses, raceObjSave) {
                 coursesObjectSave.push(coSave);
                 if (co.course_elements) {
                     co.course_elements.forEach((ce) => {
+                        // For reused elements, should have same id to be able to use correct course element positions
+                        const existingElement = coursesElementSave.find(
+                            (ee) => ee.original_id === ce.id
+                        );
                         const element = {
-                            id: uuidv4(),
+                            id: existingElement?.id || uuidv4(),
                             original_id: ce.id,
                             race: raceObjSave.id,
                             race_original_id: raceObjSave.original_id,


### PR DESCRIPTION
Also register failed url if there are no positions or boats

Take note of the start line on this race, one of the point is not moving on prod
Original race from georacing website
https://player.georacing.com/?event=101969&race=98584

Prod scraped of the same race
https://syrf.io/playback?raceId=6ca4c5a2-aa37-4ba5-8fb7-662e77654343

(Fixed) Dev scraped of the same race
https://dev.syrf.io/playback?raceId=eb146554-cc59-4153-9c46-254648b626f7